### PR TITLE
Retry port acquisition with exponential backoff

### DIFF
--- a/src/Internal/Plutip/Server.purs
+++ b/src/Internal/Plutip/Server.purs
@@ -113,6 +113,7 @@ import Effect.Aff.Class (liftAff)
 import Effect.Aff.Retry
   ( RetryPolicy
   , constantDelay
+  , exponentialBackoff
   , limitRetriesByCumulativeDelay
   , recovering
   )
@@ -436,15 +437,16 @@ configCheck cfg =
 
 -- | Throw an exception if any of the given ports is occupied.
 checkPortsAreFree :: Array { port :: UInt, service :: String } -> Aff Unit
-checkPortsAreFree ports = do
-  occupiedServices <- Array.catMaybes <$> for ports \{ port, service } -> do
-    isPortAvailable port <#> if _ then Nothing else Just (port /\ service)
-  unless (Array.null occupiedServices) do
-    liftEffect $ throw
-      $
-        "Unable to run the following services, because the ports are occupied:\
-        \\n"
-      <> foldMap printServiceEntry occupiedServices
+checkPortsAreFree ports =
+  void $ recovering portCheckRetryPolicy ([ \_ _ -> pure true ]) \_ -> do
+    occupiedServices <- Array.catMaybes <$> for ports \{ port, service } -> do
+      isPortAvailable port <#> if _ then Nothing else Just (port /\ service)
+    unless (Array.null occupiedServices) do
+      liftEffect $ throw
+        $
+          "Unable to run the following services, because the ports are occupied:\
+          \\n"
+        <> foldMap printServiceEntry occupiedServices
   where
   printServiceEntry :: UInt /\ String -> String
   printServiceEntry (port /\ service) =
@@ -729,6 +731,11 @@ makeClusterContractEnv cleanupRef cfg = do
     stopContractEnv
     $ pure
     <<< { env: _, printLogs, clearLogs }
+
+portCheckRetryPolicy :: RetryPolicy
+portCheckRetryPolicy =
+  limitRetriesByCumulativeDelay (Milliseconds 5000.0)
+    $ exponentialBackoff (Milliseconds 100.0)
 
 defaultRetryPolicy :: RetryPolicy
 defaultRetryPolicy = limitRetriesByCumulativeDelay (Milliseconds 3000.00) $


### PR DESCRIPTION
Closes # .

### Pre-review checklist

- [ ] All code has been formatted using our config (`make format`)
- [ ] Any new API features or modification of existing behavior are covered with tests
- [ ] The template (`templates/ctl-scaffold`) has been [updated](https://github.com/Plutonomicon/cardano-transaction-lib/blob/develop/doc/development.md#maintaining-the-template)
- [ ] The changelog has been updated under the `## Unreleased` header, using the appropriate sub-headings (`### Added`, `### Changed`, `### Removed`, `### Fixed`), and the links to the appropriate issues/PRs have been included

This PR adds an exponential backoff retry mechanism to the `checkPortsAreFree` function in `src/Internal/Plutip/Server.purs`. Previously, the server would exit if required ports were occupied. Now, it retries port checks with an initial 100ms delay, exponentially increasing, and a cumulative delay limit of 5 seconds, improving resilience.

---
<a href="https://cursor.com/background-agent?bcId=bc-eea58d77-b4d2-47fb-9a07-51f1ad059a63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eea58d77-b4d2-47fb-9a07-51f1ad059a63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

